### PR TITLE
Fix bias in large area algorithm

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ import ALGO from './algoTypes.js';
 
 const autosolve = false;
 const maxSeed = 10000000;
-const version = 'v 1.15';
+const version = 'v 1.16';
 
 const defaultConfig = {
   'size': {x: 9, y: 9} ,

--- a/src/Minefield.js
+++ b/src/Minefield.js
@@ -93,14 +93,14 @@ class Minefield {
         if (!newSetToIgnore.has(x, y))
           options.add(x, y);
       });
-      const selected = options.randomSubset(totalMines, this.rng);
-      selected.forEachXYKey((x, y, key) => {
+      const selected = options.randomSubset(Math.ceil(area/30), this.rng);
+      selected.toXYShuffledArray(this.rng).forEach(([x, y]) => {
         if (area - newSetToIgnore.size === totalMines) return;
         this.grid.forEachNeighbor(x, y, (xx, yy) => {
           if (selected.hasXY(xx, yy) || newSetToIgnore.hasXY(xx, yy))
-            newSetToIgnore.addKey(key);
+            newSetToIgnore.addXY(x, y);
         });
-      })
+      });
     }
     console.log('area - newSetToIgnore.size: ', area - newSetToIgnore.size);
     this.placeMinesRandomly(totalMines, newSetToIgnore)

--- a/src/XYSet.js
+++ b/src/XYSet.js
@@ -49,6 +49,16 @@ class XYSet {
   delete() { return this.select(arguments, this.deleteKey.bind(this), this.deleteXY.bind(this)); }
 
   // Advanced methods below
+  toXYShuffledArray(rng) {
+    const result = [];
+    this.forEachXY((x, y) => result.push([x, y]));
+    for (let i = result.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      [result[i], result[j]] = [result[j], result[i]];
+    }
+    return result;
+  }
+
   randomSubset(n, rng) {
     if (rng === undefined) rng = Math.random;
     let result = new XYSet(this.grid);


### PR DESCRIPTION
The algorithm creating large areas without mines had a bias that caused most of the mines to be towards the bottom of the field. This updated version removes the bias.